### PR TITLE
CC65_PATH support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,7 @@ Prerequisites
 
 **Install the cc65 compiler suite**
 
-Most Linux distributions have a prepackaged cc65, but often it is outdated. 
-
-The default location for cc65 binaries is in /usr (so ca65, ld65 and so on are present in /usr/bin/ca65, etc). If installed in another location, set the CC65_PATH variable to the path where the binaries exist. For example:
-
-    $ CC65_PATH=/usr/local/cc65/bin build.sh ...
+Most Linux distributions have a prepackaged cc65, but often it is outdated. Should you run into issues, build the latest version from https://github.com/cc65/cc65.git
 
 **Install the prerequisites for building GCC**
 
@@ -59,6 +55,10 @@ Check out this repository, and check out the GCC repository proper as a subdirec
 Now build by running the build.sh script, e.g. as:
 
     $ ./build.sh 2>&1 | tee build.log
+
+The default location for cc65 binaries is in /usr (so ca65, ld65 and so on are present in /usr/bin/ca65, etc). If installed in another location, set the CC65_PATH variable to the path where the binaries exist. For example:
+
+    $ CC65_PATH=/usr/local/cc65/bin build.sh ...
 
 After a while, you should have a 6502 cross-compiler in a directory named 'prefix'.
 

--- a/README.md
+++ b/README.md
@@ -6,33 +6,41 @@ Build tools, tiny C library, etc. for gcc-6502 port.
 Prerequisites
 -------------
 
-The cc65 compiler (https://github.com/cc65/cc65) must be installed before building. Most Linux distributions have a 
-prepackaged cc65, but often it is outdated. 
+**Install the cc65 compiler suite**
 
-The default location for cc65 binaries is in /usr (so ca65, ld65 and so on are present in /usr/bin/ca65, etc). If installed
-in another location, set the CC65_PATH variable to the path where the binaries exist. For example:
+Most Linux distributions have a prepackaged cc65, but often it is outdated. 
+
+The default location for cc65 binaries is in /usr (so ca65, ld65 and so on are present in /usr/bin/ca65, etc). If installed in another location, set the CC65_PATH variable to the path where the binaries exist. For example:
 
     $ CC65_PATH=/usr/local/cc65/bin build.sh ...
 
- - Install all the prerequisites for building GCC 
+**Install the prerequisites for building GCC**
 
     For Debian-based distros:
     # apt-get build-dep gcc-4.8
 
-    For RedHat-based distros
-    # yum install -y gcc gcc-c++ mpfr-devel gmp-devel libmpc-devel flex    
+    For RedHat-based distros:
+    # yum install -y gcc gcc-c++ mpfr-devel gmp-devel libmpc-devel flex
+
+**Install Boost development libraries**
 
 For semi65x (the included simulator), you also need Boost development libraries:
 
+    For Debian-based distros:
     # apt-get install libboost-dev libboost-regex-dev
-
-or
-
+    
+    For RedHat-based distros:
     # yum install -y boost boost-devel
+
+**Install DejaGNU (optional)**
 
 For running the GCC regression tests you will need to have DejaGNU installed:
 
+    For Debian-based distros:
     # apt-get install dejagnu
+    
+    For RedHat-based distros:
+    # yum install -y dejagnu
 
 Work in progress
 ----------------

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ For RedHat-based systems, install the requirements like so:
 For semi65x (the included simulator), you also need Boost development libraries:
 
     # apt-get install libboost-dev libboost-regex-dev
+
 or
+
     # yum install -y boost boost-devel
 
 For running the GCC regression tests you will need to have DejaGNU installed:

--- a/README.md
+++ b/README.md
@@ -6,16 +6,29 @@ Build tools, tiny C library, etc. for gcc-6502 port.
 Prerequisites
 -------------
 
-You need to install cc65 in /usr (so ca65, ld65 and so on are present in /usr/bin/ca65 etc.) before building. On a
-Debian system you should also have all the prerequisites for building GCC installed, e.g.:
+The cc65 compiler (https://github.com/cc65/cc65) must be installed before building. Most Linux distributions have a 
+prepackaged cc65, but often it is outdated. 
+
+The default location for cc65 binaries is in /usr (so ca65, ld65 and so on are present in /usr/bin/ca65, etc). If installed
+in another location, set the CC65_PATH variable to the path where the binaries exist. For example:
+
+    $ CC65_PATH=/usr/local/cc65/bin build.sh ...
+
+On a Debian system you should also have all the prerequisites for building GCC installed, e.g.:
 
     # apt-get build-dep gcc-4.8
 
 or similar.
 
+For RedHat-based systems, install the requirements like so:
+
+    # yum install -y gcc gcc-c++ mpfr-devel gmp-devel libmpc-devel flex    
+
 For semi65x (the included simulator), you also need Boost development libraries:
 
     # apt-get install libboost-dev libboost-regex-dev
+or
+    # yum install -y boost boost-devel
 
 For running the GCC regression tests you will need to have DejaGNU installed:
 

--- a/README.md
+++ b/README.md
@@ -14,14 +14,12 @@ in another location, set the CC65_PATH variable to the path where the binaries e
 
     $ CC65_PATH=/usr/local/cc65/bin build.sh ...
 
-On a Debian system you should also have all the prerequisites for building GCC installed, e.g.:
+ - Install all the prerequisites for building GCC 
 
+    For Debian-based distros:
     # apt-get build-dep gcc-4.8
 
-or similar.
-
-For RedHat-based systems, install the requirements like so:
-
+    For RedHat-based distros
     # yum install -y gcc gcc-c++ mpfr-devel gmp-devel libmpc-devel flex    
 
 For semi65x (the included simulator), you also need Boost development libraries:

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash 
 thisdir="$(dirname "$0")"
 thisdir="$(readlink -f "$thisdir")"
 cd "$thisdir"
@@ -37,6 +37,10 @@ MAKETARGET=all
 INSTALLTARGET=install
 PARALLELISM="-j 4"
 
+CC65_PATH="${CC65_PATH:-/usr/bin}"
+CA65_PATH="${CC65_PATH}/ca65"
+LD65_PATH="${CC65_PATH}/ld65"
+
 if [ "$startpos" -le 1 ]; then
 rm -rf gcc-build
 mkdir gcc-build
@@ -46,7 +50,7 @@ echo "* Building stage 1 compiler *"
 echo "*****************************"
 echo
 pushd gcc-build
-../gcc-src/configure --prefix="$thisdir/prefix" --with-sysroot="$thisdir/prefix/6502" --with-build-sysroot="$thisdir/prefix/6502" --target=6502 --enable-languages=c --with-as=/usr/bin/ca65 --with-ld=/usr/bin/ld65 --without-headers --with-newlib --disable-nls --disable-decimal-float --disable-libssp --disable-threads --disable-libatomic --disable-libitm --disable-libsanitizer --disable-libquadmath --disable-lto --enable-sjlj-exceptions --without-isl
+../gcc-src/configure --prefix="$thisdir/prefix" --with-sysroot="$thisdir/prefix/6502" --with-build-sysroot="$thisdir/prefix/6502" --target=6502 --enable-languages=c --with-as=${CA65_PATH} --with-ld=${LD65_PATH} --without-headers --with-newlib --disable-nls --disable-decimal-float --disable-libssp --disable-threads --disable-libatomic --disable-libitm --disable-libsanitizer --disable-libquadmath --disable-lto --enable-sjlj-exceptions --without-isl
 cat > do-make.sh << EOF
 #!/bin/bash
 set -e
@@ -87,7 +91,7 @@ echo
 rm -rf gcc-build-2
 mkdir gcc-build-2
 pushd gcc-build-2
-../gcc-src/configure --prefix="$thisdir/prefix" --with-sysroot="$thisdir/prefix/6502" --with-build-sysroot="$thisdir/prefix/6502" --target=6502 --enable-languages=c --with-as=/usr/bin/ca65 --with-ld=/usr/bin/ld65 --disable-nls --disable-decimal-float --disable-libssp --disable-threads --disable-libatomic --disable-libitm --disable-libsanitizer --disable-libquadmath --disable-lto --enable-sjlj-exceptions --without-isl
+../gcc-src/configure --prefix="$thisdir/prefix" --with-sysroot="$thisdir/prefix/6502" --with-build-sysroot="$thisdir/prefix/6502" --target=6502 --enable-languages=c --with-as=${CA65_PATH} --with-ld=${LD65_PATH} --disable-nls --disable-decimal-float --disable-libssp --disable-threads --disable-libatomic --disable-libitm --disable-libsanitizer --disable-libquadmath --disable-lto --enable-sjlj-exceptions --without-isl
 set -e
 make $PARALLELISM BOOT_CFLAGS="$DEBUG_FLAGS" CFLAGS="$DEBUG_FLAGS" CXXFLAGS="$DEBUG_FLAGS" AR_FOR_TARGET="$thisdir/wrappers/6502-ar" RANLIB_FOR_TARGET="$thisdir/wrappers/6502-ranlib" $MAKETARGET
 make RANLIB_FOR_TARGET="$thisdir/wrappers/6502-ranlib" $INSTALLTARGET

--- a/libtinyc/compile.sh
+++ b/libtinyc/compile.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+CC65_PATH=${CC65_PATH:-/usr/bin}
+AR65_PATH=${CC65_PATH}/ar65
+
 cd "$(dirname $0)"
 
 if [ ! "$PREFIX" ]; then
@@ -131,14 +135,14 @@ for mlib in "${MULTILIBS[@]}"; do
 	;;
     esac
     $TARGET-gcc -Os -Wall -nostdlib -I include $opts "$src" -c -o "$osdir/$obj.o"
-    ar65 a "$osdir/libtinyc.a" "$osdir/$obj.o"
+    ${AR65_PATH} a "$osdir/libtinyc.a" "$osdir/$obj.o"
   done
 
   # Build tiny maths library.
   rm -f "$osdir"/libm.a
   src="$(src_for_machine "$osdir" "math")"
   $TARGET-gcc -Os -nostdlib $opts "$src" -c -o "$osdir/math.o"
-  ar65 a "$osdir/libm.a" "$osdir/math.o"
+  ${AR65_PATH} a "$osdir/libm.a" "$osdir/math.o"
 
   mkdir -p "$PREFIX/$TARGET/$osdir/usr/lib/"
   cp -f "$osdir/libtinyc.a" "$PREFIX/$TARGET/$osdir/usr/lib"

--- a/wrappers/6502-ar
+++ b/wrappers/6502-ar
@@ -1,5 +1,6 @@
 #!/bin/sh
-AR65=/usr/bin/ar65
+CC65_PATH=${CC65_PATH:-/usr/bin}
+AR65=${CC65_PATH}/ar65
 ARG=$1
 case "$ARG" in
   "rc"|"cr")
@@ -9,4 +10,4 @@ case "$ARG" in
     ;;
 esac
 shift
-exec /usr/bin/ar65 $ARG $@
+exec ${AR65} $ARG $@


### PR DESCRIPTION
This little patch enables a different cc65 path than installed as standard on a Linux box.  